### PR TITLE
Add esearch fallback for PubMed lookups

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 streamlit
+pandas
+requests

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,5 +1,79 @@
 import streamlit as st
 import pandas as pd
+import requests
+import time
+import logging
+
+
+CONTACT_EMAIL = "william.letton@crystallise.com"
+USER_AGENT = "reverse-boolean-search/1.0"
+PMC_ID_CONVERTER_URL = "https://www.ncbi.nlm.nih.gov/pmc/utils/idconv/v1.0/"
+ESEARCH_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
+DELAY_BETWEEN_CALLS = 0.34
+MAX_RETRIES = 3
+
+session = requests.Session()
+session.headers.update({"User-Agent": USER_AGENT})
+
+
+def fetch_pubmed_id(doi: str):
+    """Return the PubMed ID for a DOI if it exists."""
+
+    def call_pmc_converter() -> str | None:
+        params = {
+            "ids": doi,
+            "format": "json",
+            "tool": "reverse_boolean_search",
+            "email": CONTACT_EMAIL,
+        }
+        for attempt in range(MAX_RETRIES):
+            try:
+                response = session.get(
+                    PMC_ID_CONVERTER_URL, params=params, timeout=10
+                )
+                if response.status_code in (429, 503):
+                    time.sleep(DELAY_BETWEEN_CALLS)
+                    continue
+                response.raise_for_status()
+                records = response.json().get("records", [])
+                if records and "pmid" in records[0]:
+                    return records[0]["pmid"]
+                return None
+            except Exception:
+                logging.exception("PubMed lookup via PMC converter failed")
+                if attempt == MAX_RETRIES - 1:
+                    return None
+            time.sleep(DELAY_BETWEEN_CALLS)
+        return None
+
+    def call_esearch() -> str | None:
+        params = {
+            "db": "pubmed",
+            "term": f"{doi}[DOI]",
+            "retmode": "json",
+            "tool": "reverse_boolean_search",
+            "email": CONTACT_EMAIL,
+        }
+        for attempt in range(MAX_RETRIES):
+            try:
+                response = session.get(ESEARCH_URL, params=params, timeout=10)
+                if response.status_code in (429, 503):
+                    time.sleep(DELAY_BETWEEN_CALLS)
+                    continue
+                response.raise_for_status()
+                ids = response.json().get("esearchresult", {}).get("idlist", [])
+                return ids[0] if ids else None
+            except Exception:
+                logging.exception("PubMed esearch lookup failed")
+                if attempt == MAX_RETRIES - 1:
+                    return None
+            time.sleep(DELAY_BETWEEN_CALLS)
+        return None
+
+    pmid = call_pmc_converter()
+    if pmid:
+        return pmid
+    return call_esearch()
 
 st.title("🎈 A Will App")
 st.write(
@@ -13,7 +87,21 @@ if uploaded_file is not None:
     # Read the CSV into a DataFrame
     try:
         df = pd.read_csv(uploaded_file)
-        # Display the DataFrame with scrolling if it is large
         st.dataframe(df, use_container_width=True, height=400)
+
+        if st.button("Check records in PubMed"):
+            if "DOI" not in df.columns:
+                st.error("The uploaded file must contain a 'DOI' column.")
+            else:
+                result_df = df.copy()
+                in_pubmed = []
+                pmids = []
+                for doi in result_df["DOI"].fillna(""):
+                    pmid = fetch_pubmed_id(doi) if doi else None
+                    in_pubmed.append(pmid is not None)
+                    pmids.append(pmid)
+                result_df["in_pubmed"] = in_pubmed
+                result_df["PMID"] = pmids
+                st.dataframe(result_df, use_container_width=True, height=400)
     except Exception as e:
         st.error(f"Failed to read CSV: {e}")


### PR DESCRIPTION
## Summary
- support fallback PubMed lookup using `esearch` when the PMC converter returns no PMID

## Testing
- `python -m py_compile streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_b_6847104c2ba08329b649e7da94bd32fe